### PR TITLE
Update to allow for custom file extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = function (options) {
     try {
       var html = kit(file.path);
       file.contents = new Buffer(html);
-      file.path = gutil.replaceExtension(file.path, '.html');
+      file.path = (options.fileExtension) ? gutil.replaceExtension(file.path, options.fileExtension) : gutil.replaceExtension(file.path, '.html');
       self.push(file);
     } catch( e ) {
       self.emit('error', new PluginError('gulp-kit', e));


### PR DESCRIPTION
In CodeKit, you're able to set a custom output extension for kit files. I'm using that to output .kit files to .php, so this would allow the same functionality.

run with kit({fileExtension: '.php'})
