### PR TITLE
Added option to pass Code Kit variables and forbidden paths through to node-kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ plugin.
       .pipe( kit({compilePartials : true}) )
       // ... further pipes, as above
     
+You can also pass through any user-defined CodeKit variables by passing
+`{ variables: { key: value, key: value, etc. }}` to the plugin.
+
+      // ... as above
+      .pipe( kit({			
+          variables: {
+				"$uiVer": pkg.version,
+				"$bsVer": "3.1"
+		}}) )
+      // ... further pipes, as above

--- a/index.js
+++ b/index.js
@@ -4,13 +4,15 @@ var gutil = require('gulp-util');
 var PluginError = gutil.PluginError;
 var path = require('path');
 var partialPrefix = '_';
-  
-function isPartial(filepath) { 
-  return path.basename(filepath)[0] === partialPrefix; 
+
+function isPartial(filepath) {
+  return path.basename(filepath)[0] === partialPrefix;
 }
 
 module.exports = function (options) {
   options = options || {};
+	options.variables = options.variables || {};
+	options.forbiddenPaths = options.forbiddenPaths || [];
 
   function transform (file, enc, next) {
     var self = this;
@@ -30,9 +32,9 @@ module.exports = function (options) {
     }
 
     try {
-      var html = kit(file.path);
+      var html = new kit.Kit(file.path, options.variables, options.forbiddenPaths).toString();
       file.contents = new Buffer(html);
-      file.path = (options.fileExtension) ? gutil.replaceExtension(file.path, options.fileExtension) : gutil.replaceExtension(file.path, '.html');
+			file.path = (options.fileExtension) ? gutil.replaceExtension(file.path, options.fileExtension) : gutil.replaceExtension(file.path, '.html');
       self.push(file);
     } catch( e ) {
       self.emit('error', new PluginError('gulp-kit', e));


### PR DESCRIPTION
To simplify our deployment process, I wanted to be able to define variables in JSON to be able to use the same variable file for both Code Kit files and static HTML merges. After doing some research into node-kit, I found that node-kit had the ability to take a predefined object containing variables as an input, so I modified the call in gulp-kit to pass these parameters through if they are present. They default to an empty object and an empty array respectively in order to maintain the existing default behavior. This PR also includes the changes from Josh's file extension option as well since I found that useful.
