### PR TITLE
node-kit treats the forbiddenPaths parameter as mutable

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = function (options) {
     }
 
     try {
-      var html = new kit.Kit(file.path, options.variables, options.forbiddenPaths).toString();
+      var html = new kit.Kit(file.path, options.variables, options.forbiddenPaths.slice()).toString();
       file.contents = new Buffer(html);
 			file.path = (options.fileExtension) ? gutil.replaceExtension(file.path, options.fileExtension) : gutil.replaceExtension(file.path, '.html');
       self.push(file);


### PR DESCRIPTION
node-kit treats the forbiddenPaths parameter as mutable, and will add to this array for each new import.

Because gulp-kit maintains a single copy of this array, and re-uses it for each fresh import, node-kit is continually adding new values into this array, and eventually stumbles over itself.

The fix is to send a fresh copy of this array into node-kit for each new file being compiled.