### PR TITLE
Gulp watch waits for an 'end' event

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ module.exports = function (options) {
       self.push(file);
     } catch( e ) {
       self.emit('error', new PluginError('gulp-kit', e));
+      self.emit('end');
     }
 
     next();


### PR DESCRIPTION
Gulp watch waits for an 'end' event, which is not currently appearing if the kit compiler encounters an error.

This prevents gulp watch from continuing with additional file changes.

By emitting an 'end' event, gulp watch will continue, even in case of an error.

See https://github.com/gulpjs/gulp/issues/259