### PR TITLE
Bump node-kit version to 0.11.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/lukx/gulp-kit/issues"
   },
   "dependencies": {
-    "node-kit": "0.9.0",
+    "node-kit": "0.11.0",
     "through2": "~0.6.1",
     "gulp-util": "~3.0.1"
   }


### PR DESCRIPTION
This permits the use of optional variables.